### PR TITLE
Add MLX support for Apple Silicon with hardware detection & config

### DIFF
--- a/rag/file_conversion_router/conversion/pdf_converter.py
+++ b/rag/file_conversion_router/conversion/pdf_converter.py
@@ -126,7 +126,6 @@ class PdfConverter(BaseConverter):
         # Convert the PDF to Markdown using Nougat.
         # self._to_markdown_using_native_nougat_cli(pdf_without_images_path, output_path)
         self._to_markdown_using_tai_nougat(pdf_without_images_path, output_path)
-        # self._to_markdown_using_mlx_nougat(pdf_without_images_path, output_path)
 
         # Now change the file name of generated mmd file to align with the expected md file path from base converter
         output_mmd_path = output_path.with_suffix(".mmd")
@@ -144,16 +143,19 @@ class PdfConverter(BaseConverter):
         The native nougat cli is in the predict.py from meta nougat repo.
         Parameters except input and output path are hard coded for now.
         """
+        default_nougat_config = TAINougatConfig()
         command = [
             "nougat",
             str(input_pdf_path),
             # nougat requires the argument output path to be a directory, not file, so we need to handle it here
             "-o",
             str(output_path.parent),
-            "--no-skipping",
+            "--no-skipping" if not default_nougat_config.skipping else "",
+            "--recompute" if default_nougat_config.recompute else "",
             "--model",
-            "0.1.0-base"
+            default_nougat_config.model_tag,
         ]
+        command = [str(arg) for arg in command]
         try:
             result = subprocess.run(command, check=False, capture_output=True, text=True)
             self._logger.info(f"Output: {result.stdout}")

--- a/rag/file_conversion_router/services/tai_nougat_service/README.md
+++ b/rag/file_conversion_router/services/tai_nougat_service/README.md
@@ -1,0 +1,14 @@
+# TAI Nougat Service
+
+The TAI Nougat Service is an optimized and refined version of the original [Meta Nougat](https://github.com/facebookresearch/nougat) service, developed to enhance performance and maintainability.
+
+## Key Enhancements
+
+- **Performance Optimization**
+  - Implemented **Dependency Injection** to reduce repeated model loading, resulting in significant time savings.
+    - Testing on developer laptops within our team shows a reduction of 4 to 8 seconds per PDF, depending on the specific device.
+  - **Better Support for Apple Chips**. It supports hard-ware detection and can use MLX instead of Torch for Apple Chips. This saves conversion time significantly for Apple Chip Devices.
+    - By @perryzjc 's testing, a M1 Pro Chip Macbook Pro takes less than 30 seconds to convert 10 pages PDF, compared to original 10 mins in @perryzjc's device.
+
+- **Code Refactoring**
+  - Improved the readability and maintainability of the codebase to facilitate easier future development and collaboration.

--- a/rag/file_conversion_router/services/tai_nougat_service/__init__.py
+++ b/rag/file_conversion_router/services/tai_nougat_service/__init__.py
@@ -1,119 +1,18 @@
-import logging
-import re
-from pathlib import Path
-from typing import List
-
-from dependency_injector import containers, providers
-from dependency_injector.wiring import Provide, inject
-from nougat import NougatModel
-from nougat.postprocessing import markdown_compatible
-from nougat.utils.checkpoint import get_checkpoint
-from nougat.utils.dataset import LazyDataset
-from nougat.utils.device import move_to_device
-from torch.utils.data import ConcatDataset, DataLoader
-from tqdm import tqdm
-
-from .nougat_config import NougatConfig
-
-logging.basicConfig(level=logging.INFO)
+from .config_nougat.tai_nougat_config import TAINougatConfig
+from .mlx_nougat_service import api as mlx_nougat_api
+from .torch_nougat_service import api as torch_nougat_api
 
 
-def create_model(config: NougatConfig) -> NougatModel:
-    if config.checkpoint is None or not config.checkpoint.exists():
-        config.checkpoint = get_checkpoint(config.checkpoint, model_tag=config.model_tag)
-
-    model = NougatModel.from_pretrained(config.checkpoint)
-    model = move_to_device(model, bf16=not config.full_precision, cuda=config.batch_size > 0)
-    model.eval()
-    print("model loaded")  # debug
-    return model
-
-
-class NougatContainer(containers.DeclarativeContainer):
-    model = providers.Singleton(
-        create_model,
-        config=NougatConfig()
-    )
-
-
-def load_datasets(config: NougatConfig, model: NougatModel) -> List[LazyDataset]:
-    datasets = []
-    for pdf in config.pdf_paths:
-        if not pdf.exists():
-            continue
-        if config.output_dir:
-            out_path = config.output_dir / pdf.with_suffix(".mmd").name
-            if out_path.exists() and not config.recompute:
-                logging.info(f"Skipping {pdf.name}, already computed. Run with recompute=True to convert again.")
-                continue
-        try:
-            dataset = LazyDataset(
-                pdf,
-                model.encoder.prepare_input,
-                config.pages,
-            )
-            datasets.append(dataset)
-        except Exception as e:
-            logging.info(f"Could not load file {str(pdf)}: {e}")
-    return datasets
-
-
-def process_output(output: str, page_num: int, config: NougatConfig) -> str:
-    if output.strip() == "[MISSING_PAGE_POST]":
-        return f"\n\n[MISSING_PAGE_EMPTY:{page_num}]\n\n"
-    if config.markdown_compatible:
-        output = markdown_compatible(output)
-    return output
-
-
-@inject
-def main(config: NougatConfig, model: NougatModel = Provide[NougatContainer.model]):
-    datasets = load_datasets(config, model)
-
-    if not datasets:
-        logging.info("No valid datasets found.")
-        return
-
-    dataloader = DataLoader(
-        ConcatDataset(datasets),
-        batch_size=config.batch_size,
-        shuffle=False,
-        collate_fn=LazyDataset.ignore_none_collate,
-    )
-
-    predictions = []
-    file_index = 0
-    page_num = 0
-
-    for sample, is_last_page in tqdm(dataloader):
-        model_output = model.inference(image_tensors=sample, early_stopping=config.skipping)
-
-        for j, output in enumerate(model_output["predictions"]):
-            if page_num == 0:
-                logging.info(f"Processing file {datasets[file_index].name} with {datasets[file_index].size} pages")
-            page_num += 1
-
-            processed_output = process_output(output, page_num, config)
-            predictions.append(processed_output)
-            if is_last_page[j]:
-                out = "".join(predictions).strip()
-                out = re.sub(r"\n{3,}", "\n\n", out).strip()
-                if config.output_dir:
-                    out_path = config.output_dir / Path(is_last_page[j]).with_suffix(".mmd").name
-                    out_path.parent.mkdir(parents=True, exist_ok=True)
-                    out_path.write_text(out, encoding="utf-8")
-                else:
-                    print(out, "\n\n")
-                predictions = []
-                page_num = 0
-                file_index += 1
-
-
-def run_nougat(config: NougatConfig):
+def run_nougat(config: TAINougatConfig):
     """Run Nougat with the provided configuration.
     model is initialized using config only on the first time run_nougat is called .
     """
-    if not hasattr(run_nougat, "container"):
-        run_nougat.container = NougatContainer()
-    run_nougat.container.wire(modules=[__name__])
-    main(config)
+    input_path = config.pdf_paths[0]
+    output_dir = config.output_dir
+
+    using_torch = config.using_torch
+
+    if using_torch:
+        torch_nougat_api.convert_pdf_to_mmd(input_path, output_dir)
+    else:
+        mlx_nougat_api.convert_pdf_to_mmd(input_path, output_dir)

--- a/rag/file_conversion_router/services/tai_nougat_service/api.py
+++ b/rag/file_conversion_router/services/tai_nougat_service/api.py
@@ -1,18 +1,15 @@
 import logging
 
 from .__init__ import run_nougat
-from .nougat_config import NougatConfig
+from .config_nougat.tai_nougat_config import TAINougatConfig
 
 logging.basicConfig(level=logging.INFO)
 
 
-def convert_pdf_to_mmd(config: NougatConfig) -> None:
+def convert_pdf_to_mmd(config: TAINougatConfig) -> None:
     """Converts a PDF file to MMD format using TAI Nougat.
     """
-    logging.info(
-        "Initialized NougatConfig",
-        extra={"config": config}
-    )
+    logging.info(f"Initialized NougatConfig. Config: {config}")
 
     try:
         logging.info("Executing conversion process.")

--- a/rag/file_conversion_router/services/tai_nougat_service/config_nougat/nougat_config.py
+++ b/rag/file_conversion_router/services/tai_nougat_service/config_nougat/nougat_config.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Literal
 
 from nougat.utils.device import default_batch_size
 
@@ -9,7 +9,7 @@ from nougat.utils.device import default_batch_size
 class NougatConfig:
     batch_size: int = default_batch_size()
     checkpoint: Optional[Path] = None
-    model_tag: str = "0.1.0-base"
+    model_tag: Literal["0.1.0-base", "1.0.0-small"] = "0.1.0-base"
     output_dir: Optional[Path] = None
     recompute: bool = True
     full_precision: bool = False

--- a/rag/file_conversion_router/services/tai_nougat_service/config_nougat/tai_nougat_config.py
+++ b/rag/file_conversion_router/services/tai_nougat_service/config_nougat/tai_nougat_config.py
@@ -1,0 +1,36 @@
+"""Compared to the default NougatConfig, TAINougatConfig includes an additional configurable field, using_torch
+
+Currently, other TAI Nougat functionalities, such as Dependency Injection, are not configurable.
+"""
+import logging
+from dataclasses import dataclass, field
+from typing import Callable, Union
+
+from .nougat_config import NougatConfig
+
+from rag.file_conversion_router.utils.hardware_detection import detect_is_apple_silicon
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def determine_using_torch() -> bool:
+    is_apple_silicon = detect_is_apple_silicon()
+    logger.info(f"Apple Silicon detected: {is_apple_silicon}")
+    # By default, using torch is False on Apple Silicon, True otherwise
+    return not is_apple_silicon
+
+
+@dataclass
+class TAINougatConfig(NougatConfig):
+    # Allow either a boolean or a callable that returns a boolean
+    using_torch: Union[bool, Callable[[], bool]] = field(default_factory=determine_using_torch)
+
+    def __post_init__(self):
+        if callable(self.using_torch):
+            self.using_torch = self.using_torch()
+
+        if self.using_torch:
+            logger.info("Using Torch for Nougat PDF conversion.")
+        else:
+            logger.info("Using MLX for Nougat PDF conversion for Apple Silicon for better performance.")

--- a/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/README.md
+++ b/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/README.md
@@ -1,0 +1,7 @@
+# MLX Nougat Service
+
+The MLX Nougat Service was inspired by a GitHub repository and a Reddit post. We have modified it to support more flexible configurations.
+
+## Credits
+
+The code in the `faster_nougat` directory originates from [this repository](https://github.com/zhuzilin/faster-nougat). The MLX acceleration feature was inspired by [this Reddit post](https://www.reddit.com/r/LocalLLaMA/comments/1cnnwrp/a_faster_nougat_implementation_with_mlx_for/).

--- a/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/__init__.py
+++ b/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/__init__.py
@@ -1,0 +1,69 @@
+"""Modified init code from the 'faster_nougat' package, to support more flexible configuration options.
+"""
+
+import os
+from pathlib import Path
+from typing import Tuple, Any
+
+from tqdm import tqdm
+
+from .faster_nougat import generate
+from .faster_nougat.utils import get_model_and_processor, extract_pdf_pages_as_images
+from ..config_nougat.tai_nougat_config import TAINougatConfig
+
+
+class ModelNameMapper:
+    tag_map = {
+        "0.1.0-base": "facebook/nougat-base",
+        "1.0.0-small": "facebook/nougat-small",
+    }
+
+    @classmethod
+    def get_model_name(cls, tag: str) -> str:
+        return cls.tag_map[tag]
+
+
+class ModelManager:
+    def __init__(self):
+        self.model = None
+        self.processor = None
+
+    def get_model_and_processor(self) -> Tuple[Any, Any]:
+        if self.model is None or self.processor is None:
+            self.model, self.processor = get_model_and_processor(ModelNameMapper.
+                                                                 get_model_name(TAINougatConfig.model_tag))
+        return self.model, self.processor
+
+
+model_manager = ModelManager()
+
+
+def process_page(page_idx: int, image: Any, model: Any, processor: Any) -> str:
+    pixel_values = processor(image, return_tensors="pt").pixel_values
+    outputs = generate(model, pixel_values, max_new_tokens=4096, disable_tqdm=True)
+    sequence = processor.batch_decode([outputs], skip_special_tokens=True)[0]
+    sequence = processor.post_process_generation(sequence, fix_markdown=False)
+    return f"\n\n# Page {page_idx + 1}\n\n{sequence}"
+
+
+def main(input_pdf_path: Path, output_dir: Path) -> None:
+    pdf_path = str(input_pdf_path)
+    output_file_path = output_dir / f"{input_pdf_path.stem}.mmd"
+
+    if not pdf_path.endswith(".pdf"):
+        pdf_path += ".pdf"
+
+    images = extract_pdf_pages_as_images(pdf_path)
+    pages = list(range(len(images)))
+
+    model, processor = model_manager.get_model_and_processor()
+
+    full_content = ""
+    for page_idx in tqdm(pages):
+        image = images[page_idx]
+        full_content += process_page(page_idx, image, model, processor)
+
+    with open(output_file_path, "w") as f:
+        f.write(full_content.strip())
+
+    print(f"MMD content has been written to {output_file_path}")

--- a/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/api.py
+++ b/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/api.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+from . import main
+
+
+def convert_pdf_to_mmd(input_pdf_path: Path, output_dir_path: Path) -> None:
+    main(input_pdf_path, output_dir_path)

--- a/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/faster_nougat/__init__.py
+++ b/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/faster_nougat/__init__.py
@@ -1,0 +1,1 @@
+from .generate import generate

--- a/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/faster_nougat/convert.py
+++ b/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/faster_nougat/convert.py
@@ -1,0 +1,53 @@
+import torch
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+
+def deconvert(mlx_module):
+    if isinstance(mlx_module, mx.array):
+        return torch.from_numpy(np.array(mlx_module))
+    else:
+        raise NotImplementedError()
+
+
+def convert(hf_module):
+    if isinstance(hf_module, torch.Tensor):
+        return mx.array(hf_module.numpy())
+
+    if isinstance(hf_module, torch.nn.Linear):
+        has_bias = hf_module.bias is not None
+        mlx_module = nn.Linear(
+            hf_module.in_features,
+            hf_module.out_features,
+            bias=has_bias,
+        )
+        weights = [("weight", convert(hf_module.weight))]
+        if has_bias:
+            weights.append(("bias", convert(hf_module.bias)))
+    elif isinstance(hf_module, torch.nn.LayerNorm):
+        has_bias = hf_module.bias is not None
+        mlx_module = nn.LayerNorm(
+            dims=hf_module.normalized_shape[0],
+            eps=hf_module.eps,
+            affine=hf_module.elementwise_affine,
+            bias=has_bias,
+        )
+        has_weight = hf_module.weight is not None
+        weights = []
+        if has_weight:
+            weights.append(("weight", convert(hf_module.weight)))
+        if has_bias:
+            weights.append(("bias", convert(hf_module.bias)))
+
+    elif isinstance(hf_module, torch.nn.Embedding):
+        mlx_module = nn.Embedding(
+            num_embeddings=hf_module.num_embeddings,
+            dims=hf_module.embedding_dim,
+        )
+        weights = [("weight", convert(hf_module.weight))]
+    else:
+        raise NotImplementedError(f"{type(hf_module)}")
+
+    mlx_module.load_weights(weights)
+    return mlx_module

--- a/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/faster_nougat/generate.py
+++ b/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/faster_nougat/generate.py
@@ -1,0 +1,31 @@
+import torch
+import mlx.core as mx
+from tqdm import tqdm
+from .convert import convert
+from .layers.mbart_decode import MBartDecoder
+
+
+def generate(model, pixel_values, *, max_new_tokens=4096, disable_tqdm=False):
+    with torch.no_grad():
+        encoder_outputs = model.encoder(pixel_values)
+        encoder_hidden_states = encoder_outputs[0]
+        encoder_hidden_states = convert(encoder_hidden_states).astype(mx.bfloat16)
+
+        decoder = MBartDecoder(model.decoder)
+        decoder.eval()
+        decoder.set_dtype(mx.bfloat16)
+        new_token = 0
+        outputs = [0]
+        past_key_values = None
+        for _ in tqdm(range(max_new_tokens), disable=disable_tqdm):
+            logits, past_key_values = decoder(
+                input_ids=new_token,
+                encoder_hidden_states=encoder_hidden_states,
+                past_key_values=past_key_values,
+            )
+            # greedy sampling
+            new_token = logits.argmax().item()
+            if new_token == 2:
+                break
+            outputs.append(new_token)
+    return outputs

--- a/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/faster_nougat/layers/mbart_attention.py
+++ b/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/faster_nougat/layers/mbart_attention.py
@@ -1,0 +1,89 @@
+import torch
+import mlx.core as mx
+import mlx.nn as nn
+from typing import Optional, Tuple
+from ..convert import convert
+
+
+class MBartDecoderAttention(nn.Module):
+    def __init__(self, hf_module):
+        super().__init__()
+        self.hf_module = hf_module
+
+        self.num_heads = self.hf_module.num_heads
+        self.head_dim = self.hf_module.head_dim
+        self.embed_dim = self.hf_module.embed_dim
+        self.scaling = self.hf_module.scaling
+
+        self.q_proj = convert(self.hf_module.q_proj)
+        self.k_proj = convert(self.hf_module.k_proj)
+        self.v_proj = convert(self.hf_module.v_proj)
+
+        self.out_proj = convert(self.hf_module.out_proj)
+
+    def _shape(self, tensor: torch.Tensor, seq_len: int, bsz: int):
+        # hardcode as bs=1, seqlen=1
+        return tensor.reshape(bsz, seq_len, self.num_heads, self.head_dim).transpose(
+            0, 2, 1, 3
+        )
+
+    def __call__(
+        self,
+        hidden_states: torch.Tensor,
+        key_value_states: Optional[torch.Tensor] = None,
+        past_key_value: Optional[Tuple[torch.Tensor]] = None,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+        """Input shape: Batch x Time x Channel"""
+
+        # if key_value_states are provided this layer is used as a cross-attention layer
+        # for the decoder
+        is_cross_attention = key_value_states is not None
+
+        bsz, tgt_len, _ = hidden_states.shape
+
+        # get query proj
+        query_states = self.q_proj(hidden_states)
+        # get key, value proj
+        # `past_key_value[0].shape[2] == key_value_states.shape[1]`
+        # is checking that the `sequence_length` of the `past_key_value` is the same as
+        # the provided `key_value_states` to support prefix tuning
+        if (
+            is_cross_attention
+            and past_key_value is not None
+            and past_key_value[0].shape[2] == key_value_states.shape[1]
+        ):
+            # reuse k,v, cross_attentions
+            key_states = past_key_value[0]
+            value_states = past_key_value[1]
+        elif is_cross_attention:
+            # cross_attentions
+            key_states = self._shape(self.k_proj(key_value_states), -1, bsz)
+            value_states = self._shape(self.v_proj(key_value_states), -1, bsz)
+        elif past_key_value is not None:
+            # reuse k, v, self_attention
+            key_states = self._shape(self.k_proj(hidden_states), -1, bsz)
+            value_states = self._shape(self.v_proj(hidden_states), -1, bsz)
+            key_states = mx.concatenate([past_key_value[0], key_states], axis=2)
+            value_states = mx.concatenate([past_key_value[1], value_states], axis=2)
+        else:
+            # self_attention
+            key_states = self._shape(self.k_proj(hidden_states), -1, bsz)
+            value_states = self._shape(self.v_proj(hidden_states), -1, bsz)
+
+        past_key_value = (key_states, value_states)
+
+        query_states = self._shape(query_states, tgt_len, bsz)
+
+        attn_output = mx.fast.scaled_dot_product_attention(
+            query_states, key_states, value_states, scale=self.scaling
+        )
+
+        attn_output = attn_output.transpose(0, 2, 1, 3)
+
+        # Use the `embed_dim` from the config (stored in the class) rather than `hidden_state` because `attn_output` can be
+        # partitioned across GPUs when using tensor-parallelism.
+        attn_output = attn_output.reshape(bsz, tgt_len, self.embed_dim)
+
+        attn_output = self.out_proj(attn_output)
+
+        return attn_output, past_key_value

--- a/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/faster_nougat/layers/mbart_decode.py
+++ b/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/faster_nougat/layers/mbart_decode.py
@@ -1,0 +1,66 @@
+import torch
+import mlx.nn as nn
+from typing import Optional, Tuple
+from .mbart_decoder_layer import MBartDecoderLayer
+from ..convert import convert
+
+
+class MBartDecoder(nn.Module):
+    def __init__(self, hf_model):
+        super().__init__()
+        self.lm_head = convert(hf_model.lm_head)
+
+        self.hf_model = hf_model.model.decoder
+        # embedding
+        self.embed_tokens = convert(self.hf_model.embed_tokens)
+        self.embed_positions = convert(self.hf_model.embed_positions)
+        self.layernorm_embedding = convert(self.hf_model.layernorm_embedding)
+
+        # decode layers
+        self.layers = [
+            MBartDecoderLayer(decoder_layer) for decoder_layer in self.hf_model.layers
+        ]
+
+        # output
+        self.layer_norm = convert(self.hf_model.layer_norm)
+        self.embed_scale = self.hf_model.embed_scale
+
+        self.decode_count = 0
+
+    def emb(self, input_ids: int):
+        inputs_embeds = self.embed_tokens(input_ids) * self.embed_scale
+        positions = self.embed_positions(self.decode_count + 2)
+        hidden_states = inputs_embeds + positions
+        hidden_states = self.layernorm_embedding(hidden_states)
+        return hidden_states
+
+    def __call__(
+        self,
+        input_ids: int,
+        encoder_hidden_states: Optional[torch.FloatTensor] = None,
+        past_key_values: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
+    ) -> Tuple:
+        hidden_states = self.emb(input_ids)
+        hidden_states = hidden_states.reshape(1, 1, -1)
+
+        # decoder layers
+        next_decoder_cache = ()
+        for idx, decoder_layer in enumerate(self.layers):
+            past_key_value = (
+                past_key_values[idx] if past_key_values is not None else None
+            )
+
+            layer_outputs = decoder_layer(
+                hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                past_key_value=past_key_value,
+            )
+            hidden_states = layer_outputs[0]
+
+            next_decoder_cache += (layer_outputs[1],)
+
+        hidden_states = self.layer_norm(hidden_states)
+        logits = self.lm_head(hidden_states)
+
+        self.decode_count += 1
+        return logits, next_decoder_cache

--- a/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/faster_nougat/layers/mbart_decoder_layer.py
+++ b/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/faster_nougat/layers/mbart_decoder_layer.py
@@ -1,0 +1,81 @@
+import torch
+import mlx.core as mx
+import mlx.nn as nn
+from typing import Optional, Tuple
+from ..convert import convert
+from .mbart_attention import MBartDecoderAttention
+
+
+class MBartDecoderLayer(nn.Module):
+    def __init__(self, hf_module):
+        super().__init__()
+        self.hf_module = hf_module
+
+        self.self_attn_layer_norm = convert(self.hf_module.self_attn_layer_norm)
+        self.encoder_attn_layer_norm = convert(self.hf_module.encoder_attn_layer_norm)
+
+        self.self_attn = MBartDecoderAttention(self.hf_module.self_attn)
+        self.encoder_attn = MBartDecoderAttention(self.hf_module.encoder_attn)
+
+        self.final_layer_norm = convert(self.hf_module.final_layer_norm)
+        self.fc1 = convert(self.hf_module.fc1)
+        # hardcode gelu. should be fine...
+        self.activation_fn = nn.gelu
+        self.fc2 = convert(self.hf_module.fc2)
+
+    def __call__(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        past_key_value: Optional[Tuple[torch.Tensor]] = None,
+    ) -> torch.Tensor:
+        """
+        Args:
+            hidden_states (`torch.FloatTensor`): input to the layer of shape `(batch, seq_len, embed_dim)`
+            encoder_hidden_states (`torch.FloatTensor`):
+                cross attention input to the layer of shape `(batch, seq_len, embed_dim)`
+            past_key_value (`Tuple(torch.FloatTensor)`): cached past key and value projection states
+        """
+        residual = hidden_states
+        hidden_states = self.self_attn_layer_norm(hidden_states)
+
+        # Self Attention
+        # decoder uni-directional self-attention cached key/values tuple is at positions 1,2
+        self_attn_past_key_value = (
+            past_key_value[:2] if past_key_value is not None else None
+        )
+        # add present self-attn cache to positions 1,2 of present_key_value tuple
+        hidden_states, present_key_value = self.self_attn(
+            hidden_states=hidden_states,
+            past_key_value=self_attn_past_key_value,
+        )
+
+        hidden_states = residual + hidden_states
+
+        # Cross-Attention Block
+        residual = hidden_states
+        hidden_states = self.encoder_attn_layer_norm(hidden_states)
+
+        # cross_attn cached key/values tuple is at positions 3,4 of present_key_value tuple
+        cross_attn_past_key_value = (
+            past_key_value[-2:] if past_key_value is not None else None
+        )
+        hidden_states, cross_attn_present_key_value = self.encoder_attn(
+            hidden_states=hidden_states,
+            key_value_states=encoder_hidden_states,
+            past_key_value=cross_attn_past_key_value,
+        )
+
+        hidden_states = residual + hidden_states
+
+        # add cross-attn to positions 3,4 of present_key_value tuple
+        present_key_value = present_key_value + cross_attn_present_key_value
+
+        # Fully Connected
+        residual = hidden_states
+        hidden_states = self.final_layer_norm(hidden_states)
+        hidden_states = self.activation_fn(self.fc1(hidden_states))
+        hidden_states = self.fc2(hidden_states)
+        hidden_states = residual + hidden_states
+
+        return hidden_states, present_key_value

--- a/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/faster_nougat/utils.py
+++ b/rag/file_conversion_router/services/tai_nougat_service/mlx_nougat_service/faster_nougat/utils.py
@@ -1,0 +1,49 @@
+import numpy as np
+from time import time
+from PIL import Image as PILImage
+from wand.image import Image as WandImage
+from wand.color import Color
+from transformers import NougatProcessor, VisionEncoderDecoderModel
+
+
+def get_model_and_processor(model_name):
+    print("start loading model and processor")
+    start = time()
+    processor = NougatProcessor.from_pretrained(model_name)
+    model = VisionEncoderDecoderModel.from_pretrained(model_name)
+    model.eval()
+    end = time()
+    print(f"time: {end - start:.2f} s")
+    return model, processor
+
+
+def extract_single_pdf_page_as_image(filename: str, page_idx: int, *, resolution=200):
+    assert filename.endswith(
+        ".pdf"
+    ), f"{filename} does not end with .pdf, is it a pdf file?"
+    assert page_idx > 0, f"page_idx starts from 1 to align with most pdf readers"
+    with WandImage(
+        filename=f"{filename}[{page_idx - 1}]", resolution=resolution
+    ) as wand_img:
+        wand_img.background_color = Color("white")
+        wand_img.alpha_channel = "remove"
+        numpy_array = np.array(wand_img)
+        image = PILImage.fromarray(numpy_array).convert("RGB")
+    return image
+
+
+def extract_pdf_pages_as_images(filename: str, *, resolution=200):
+    assert filename.endswith(
+        ".pdf"
+    ), f"{filename} does not end with .pdf, is it a pdf file?"
+    print(f"start extracting {filename}")
+    # Load the image using wand
+    images = []
+    with WandImage(filename=filename, resolution=resolution) as wand_imgs:
+        print(f"the pdf has {len(wand_imgs.sequence)} pages")
+        for wand_img in wand_imgs.sequence:
+            wand_img.background_color = Color("white")
+            wand_img.alpha_channel = "remove"
+            numpy_array = np.array(wand_img)
+            images.append(PILImage.fromarray(numpy_array).convert("RGB"))
+    return images

--- a/rag/file_conversion_router/services/tai_nougat_service/torch_nougat_service/README.md
+++ b/rag/file_conversion_router/services/tai_nougat_service/torch_nougat_service/README.md
@@ -1,0 +1,5 @@
+# Torch Nougat Service
+
+We have migrated code from the Meta Nougat repository to enable more flexible development of Nougat services, including support for **Dependency Injection**.
+
+The original Meta Nougat is built on Torch.

--- a/rag/file_conversion_router/services/tai_nougat_service/torch_nougat_service/__init__.py
+++ b/rag/file_conversion_router/services/tai_nougat_service/torch_nougat_service/__init__.py
@@ -1,0 +1,119 @@
+import logging
+import re
+from pathlib import Path
+from typing import List
+
+from dependency_injector import containers, providers
+from dependency_injector.wiring import Provide, inject
+from nougat import NougatModel
+from nougat.postprocessing import markdown_compatible
+from nougat.utils.checkpoint import get_checkpoint
+from nougat.utils.dataset import LazyDataset
+from nougat.utils.device import move_to_device
+from torch.utils.data import ConcatDataset, DataLoader
+from tqdm import tqdm
+
+from ..config_nougat.nougat_config import NougatConfig
+
+logging.basicConfig(level=logging.INFO)
+
+
+def create_model(config: NougatConfig) -> NougatModel:
+    if config.checkpoint is None or not config.checkpoint.exists():
+        config.checkpoint = get_checkpoint(config.checkpoint, model_tag=config.model_tag)
+
+    model = NougatModel.from_pretrained(config.checkpoint)
+    model = move_to_device(model, bf16=not config.full_precision, cuda=config.batch_size > 0)
+    model.eval()
+    print("model loaded")  # debug
+    return model
+
+
+class NougatContainer(containers.DeclarativeContainer):
+    model = providers.Singleton(
+        create_model,
+        config=NougatConfig()
+    )
+
+
+def load_datasets(config: NougatConfig, model: NougatModel) -> List[LazyDataset]:
+    datasets = []
+    for pdf in config.pdf_paths:
+        if not pdf.exists():
+            continue
+        if config.output_dir:
+            out_path = config.output_dir / pdf.with_suffix(".mmd").name
+            if out_path.exists() and not config.recompute:
+                logging.info(f"Skipping {pdf.name}, already computed. Run with recompute=True to convert again.")
+                continue
+        try:
+            dataset = LazyDataset(
+                pdf,
+                model.encoder.prepare_input,
+                config.pages,
+            )
+            datasets.append(dataset)
+        except Exception as e:
+            logging.info(f"Could not load file {str(pdf)}: {e}")
+    return datasets
+
+
+def process_output(output: str, page_num: int, config: NougatConfig) -> str:
+    if output.strip() == "[MISSING_PAGE_POST]":
+        return f"\n\n[MISSING_PAGE_EMPTY:{page_num}]\n\n"
+    if config.markdown_compatible:
+        output = markdown_compatible(output)
+    return output
+
+
+@inject
+def main(config: NougatConfig, model: NougatModel = Provide[NougatContainer.model]):
+    datasets = load_datasets(config, model)
+
+    if not datasets:
+        logging.info("No valid datasets found.")
+        return
+
+    dataloader = DataLoader(
+        ConcatDataset(datasets),
+        batch_size=config.batch_size,
+        shuffle=False,
+        collate_fn=LazyDataset.ignore_none_collate,
+    )
+
+    predictions = []
+    file_index = 0
+    page_num = 0
+
+    for sample, is_last_page in tqdm(dataloader):
+        model_output = model.inference(image_tensors=sample, early_stopping=config.skipping)
+
+        for j, output in enumerate(model_output["predictions"]):
+            if page_num == 0:
+                logging.info(f"Processing file {datasets[file_index].name} with {datasets[file_index].size} pages")
+            page_num += 1
+
+            processed_output = process_output(output, page_num, config)
+            predictions.append(processed_output)
+            if is_last_page[j]:
+                out = "".join(predictions).strip()
+                out = re.sub(r"\n{3,}", "\n\n", out).strip()
+                if config.output_dir:
+                    out_path = config.output_dir / Path(is_last_page[j]).with_suffix(".mmd").name
+                    out_path.parent.mkdir(parents=True, exist_ok=True)
+                    out_path.write_text(out, encoding="utf-8")
+                else:
+                    print(out, "\n\n")
+                predictions = []
+                page_num = 0
+                file_index += 1
+
+
+def run_nougat(config: NougatConfig):
+    """Run Nougat with the provided configuration.
+    model is initialized using config only on the first time run_nougat is called .
+    """
+    if not hasattr(run_nougat, "container"):
+        run_nougat.container = NougatContainer()
+    run_nougat.container.wire(modules=[__name__])
+    main(config)

--- a/rag/file_conversion_router/services/tai_nougat_service/torch_nougat_service/api.py
+++ b/rag/file_conversion_router/services/tai_nougat_service/torch_nougat_service/api.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+from . import run_nougat
+from ..config_nougat.nougat_config import NougatConfig
+
+
+def convert_pdf_to_mmd(input_pdf_path: Path, output_dir_path: Path) -> None:
+    config = NougatConfig(
+        pdf_paths=[input_pdf_path],
+        output_dir=output_dir_path,
+    )
+    run_nougat(config)

--- a/rag/file_conversion_router/utils/hardware_detection.py
+++ b/rag/file_conversion_router/utils/hardware_detection.py
@@ -1,3 +1,6 @@
+import platform
+import subprocess
+
 import torch
 
 
@@ -8,3 +11,19 @@ def detect_gpu_setup():
         return "mps", 1
     else:
         return "cpu", 0
+
+
+def detect_is_apple_silicon():
+    system = platform.system()
+
+    if system == "Darwin":  # macOS
+        # Check if it's Apple Silicon
+        try:
+            output = subprocess.check_output(["sysctl", "-n", "machdep.cpu.brand_string"]).decode().strip()
+            if "Apple" in output:
+                return True
+        except subprocess.CalledProcessError:
+            pass
+
+    # For all other cases (Intel, NVIDIA, others, or if Apple Silicon check fails)
+    return False

--- a/rag/requirements.txt
+++ b/rag/requirements.txt
@@ -31,3 +31,5 @@ nougat-ocr==0.1.17
 albumentations==1.4.11
 pydantic==2.8.2
 dependency_injector==4.41.0
+mlx
+wand


### PR DESCRIPTION
- Added MLX support, significantly speeding up Nougat PDF conversion on devices with Apple Silicon.
- Implemented hardware detection to determine if the device uses Apple Silicon.
- Added configuration options and refactored the architecture to enable flexible control over Nougat conversion behavior. By default, MLX is used for devices with Apple Silicon, while PyTorch is used for other devices.
- Updated the PKL file testing strategy: it currently checks for file existence, but will be enhanced in the future to compare dictionary content, including chunk data.

Additional details can be found in the 3 `README.md` files included in this PR.