### PR TITLE
Add test for comparing content in pkl files 

### DIFF
--- a/rag/requirements.txt
+++ b/rag/requirements.txt
@@ -29,6 +29,7 @@ voyageai==0.2.2
 pix2text==1.1.1
 nougat-ocr==0.1.17
 albumentations==1.4.11
+albucore==0.0.16
 pydantic==2.8.2
 dependency_injector==4.41.0
 mlx

--- a/tests/test_rag/conftest.py
+++ b/tests/test_rag/conftest.py
@@ -115,14 +115,3 @@ def helper_unit_test_on_converter(input_path: str, expected_output_paths: List[s
         assert compare_files(
             expected_paths[idx], output_file_path
         ), f"File conversion for {input_path} did not meet expectations."
-
-
-def helper_integrated_test_on_converter(input_folder: str, expected_output_folder: str, tmp_path, converter):
-    input_folder = Path(input_folder)
-
-    output_folder = tmp_path / input_folder.stem
-    output_folder.mkdir(parents=True, exist_ok=True)
-
-    for pdf_file in input_folder.glob('*.pdf'):
-
-        converter.convert(pdf_file, output_folder / pdf_file.stem)

--- a/tests/test_rag/test_file_conversion_router/test_converters/test_pdf_converter.py
+++ b/tests/test_rag/test_file_conversion_router/test_converters/test_pdf_converter.py
@@ -2,7 +2,7 @@ from typing import List
 
 import pytest
 
-from tests.test_rag.conftest import helper_unit_test_on_converter, helper_integrated_test_on_converter, load_test_cases_config
+from tests.test_rag.conftest import helper_unit_test_on_converter, load_test_cases_config
 
 
 @pytest.mark.parametrize(
@@ -11,11 +11,3 @@ from tests.test_rag.conftest import helper_unit_test_on_converter, helper_integr
 )
 def test_pdf_conversion(input_path: str, expected_output_paths: List[str], tmp_path, pdf_converter):
     helper_unit_test_on_converter(input_path, expected_output_paths, tmp_path, pdf_converter)
-
-
-@pytest.mark.parametrize(
-    "input_folder, expected_output_folder",
-    load_test_cases_config("integrated_tests", "plain_folder_3_pdfs"),
-)
-def test_pdf_conversion_integrated(input_folder: str, expected_output_folder: str, tmp_path, pdf_converter):
-    helper_integrated_test_on_converter(input_folder, expected_output_folder, tmp_path, pdf_converter)


### PR DESCRIPTION
- Created test functions for comparing chunk objects in PKL files using DeepDiff.
- Chunk content is compared based on a similarity threshold
- Chunk title and url are expected to match exactly