### PR TITLE
Add module-scoped RAG and Modules API

### DIFF
--- a/ai_chatbot_backend/app/api/router.py
+++ b/ai_chatbot_backend/app/api/router.py
@@ -2,6 +2,7 @@ from app.api.routes import (
     completions,
     courses,
     files,
+    modules,
     problems,
 )
 from fastapi import APIRouter
@@ -19,6 +20,9 @@ api_router.include_router(courses.router, prefix="/courses", tags=["courses"])
 
 # Files management
 api_router.include_router(files.router, prefix="/files", tags=["files"])
+
+# Modules management
+api_router.include_router(modules.router, prefix="/modules", tags=["modules"])
 
 # Problems management
 api_router.include_router(

--- a/ai_chatbot_backend/app/api/routes/completions.py
+++ b/ai_chatbot_backend/app/api/routes/completions.py
@@ -109,24 +109,46 @@ async def create_completion(
         print("file_uuid:", params.user_focus.file_uuid)
         print("selected_text:", params.user_focus.selected_text)
         print("chunk_index:", params.user_focus.chunk_index)
+        if params.user_focus.module_uuid:
+            print("module_uuid:", params.user_focus.module_uuid)
     elif isinstance(params, PracticeCompletionParams):
         problem_content = _get_problem_content(params, db)
 
+    # Resolve module_uuid → module_path if provided
+    module_path = None
+    user_focus = getattr(params, 'user_focus', None)
+    if user_focus and user_focus.module_uuid:
+        from app.services.module_service import module_service as _module_service
+        module = _module_service.get_by_uuid(db, user_focus.module_uuid)
+        if not module:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Module not found: {user_focus.module_uuid}",
+            )
+        module_path = module.path
+
     # Dispatch to chat or tutor pipeline
-    pipeline_fn = run_tutor_pipeline if params.tutor_mode else run_chat_pipeline
-    result = await pipeline_fn(
-        messages=params.messages,
-        user_focus=getattr(params, 'user_focus', None),
-        answer_content=getattr(params, 'answer_content', None),
-        problem_content=problem_content,
-        stream=params.stream,
-        course=params.course_code,
-        engine=llm_engine,
-        audio_response=params.audio_response,
-        sid=sid,
-        timer=timer,
-        audio_text=audio_text,
-    )
+    try:
+        pipeline_fn = run_tutor_pipeline if params.tutor_mode else run_chat_pipeline
+        result = await pipeline_fn(
+            messages=params.messages,
+            user_focus=user_focus,
+            answer_content=getattr(params, 'answer_content', None),
+            problem_content=problem_content,
+            stream=params.stream,
+            course=params.course_code,
+            engine=llm_engine,
+            audio_response=params.audio_response,
+            sid=sid,
+            timer=timer,
+            audio_text=audio_text,
+            module_path=module_path,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
 
     if params.stream:
         return StreamingResponse(result, media_type="text/event-stream")

--- a/ai_chatbot_backend/app/api/routes/modules.py
+++ b/ai_chatbot_backend/app/api/routes/modules.py
@@ -1,0 +1,85 @@
+"""
+Module routes for listing and accessing course modules
+"""
+
+import logging
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.core.dbs.metadata_db import get_metadata_db
+from app.api.deps import verify_api_token
+from app.schemas.modules import Module, ModuleListResponse
+from app.schemas.files import FileMetadata, FileListResponse
+from app.services.module_service import module_service
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@router.get("", response_model=ModuleListResponse, summary="List all modules")
+async def list_modules(
+    course_code: str = Query(..., description="Course code (e.g., CS61A)"),
+    db: Session = Depends(get_metadata_db),
+    _: bool = Depends(verify_api_token),
+):
+    """
+    List all modules for a given course.
+
+    A module is a directory grouping following these patterns:
+    - practice/*/<name>  (grandchildren of practice/)
+    - study/<name>       (children of study/)
+    - support/<name>     (children of support/)
+    """
+    try:
+        modules = module_service.list_modules(db=db, course_code=course_code)
+        return ModuleListResponse(
+            modules=[Module.from_db_model(m) for m in modules],
+            total_count=len(modules),
+            course_code=course_code,
+        )
+    except Exception as e:
+        logger.error(f"Error listing modules: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error listing modules: {str(e)}",
+        )
+
+
+@router.get("/{module_uuid}/files", response_model=FileListResponse, summary="List files in a module")
+async def list_module_files(
+    module_uuid: str,
+    page: int = Query(1, ge=1, description="Page number"),
+    limit: int = Query(100, ge=1, le=1000, description="Items per page"),
+    db: Session = Depends(get_metadata_db),
+    _: bool = Depends(verify_api_token),
+):
+    """
+    List all files within a specific module identified by its UUID.
+
+    Example:
+    - GET /api/modules/550e8400-e29b-41d4-a716-446655440000/files
+    """
+    try:
+        files = module_service.get_module_files(db=db, module_uuid=module_uuid)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error listing module files: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error listing module files: {str(e)}",
+        )
+
+    total_count = len(files)
+    start_idx = (page - 1) * limit
+    end_idx = start_idx + limit
+
+    return FileListResponse(
+        files=[FileMetadata.from_db_model(f) for f in files[start_idx:end_idx]],
+        total_count=total_count,
+        page=page,
+        limit=limit,
+        has_next=end_idx < total_count,
+        has_prev=page > 1,
+        filters_applied={"module_uuid": module_uuid},
+    )

--- a/ai_chatbot_backend/app/core/dbs/db_initializer.py
+++ b/ai_chatbot_backend/app/core/dbs/db_initializer.py
@@ -21,7 +21,7 @@ from app.core.dbs.metadata_db import (
     MetadataSessionLocal,
 )
 from app.core.models.courses import CourseModel
-from app.core.models.metadata import FileModel, ProblemModel
+from app.core.models.metadata import FileModel, ProblemModel, ModuleModel
 from app.core.mongodb_client import get_mongodb_client, load_database_mapping
 from app.config import settings
 
@@ -62,6 +62,9 @@ class DatabaseInitializer:
                     logger.warning(
                         "⚠️ Failed to load data from MongoDB, continuing with local initialization"
                     )
+
+            # Step 4: Populate modules table from file paths (idempotent)
+            self._populate_modules()
 
             # Database initialization completed
 
@@ -360,6 +363,79 @@ class DatabaseInitializer:
 
         except Exception as e:
             logger.error(f"❌ Failed to load problems from MongoDB: {e}")
+            return False
+
+    def _populate_modules(self) -> bool:
+        """
+        Scan FileModel paths to discover modules and populate the module table.
+        Idempotent — uses INSERT OR IGNORE semantics via the unique constraint.
+        """
+        import uuid as uuid_lib
+        try:
+            session = MetadataSessionLocal()
+            try:
+                # Get all files with paths containing at least one slash
+                files = session.query(FileModel.relative_path, FileModel.course_code).filter(
+                    FileModel.relative_path.like('%/%')
+                ).all()
+
+                seen: set = set()
+                new_modules = []
+
+                for relative_path, course_code in files:
+                    if not relative_path or not course_code:
+                        continue
+                    parts = relative_path.split('/')
+                    # paths are {course_dir}/{category}/... so category is at parts[1]
+                    module_path = None
+                    category = None
+
+                    if len(parts) >= 5 and parts[1] == 'practice':
+                        # {course_dir}/practice/{subdir}/{module_name}/...
+                        module_path = '/'.join(parts[:4])
+                        category = 'practice'
+                    elif len(parts) >= 4 and parts[1] == 'study':
+                        # {course_dir}/study/{module_name}/...
+                        module_path = '/'.join(parts[:3])
+                        category = 'study'
+                    elif len(parts) >= 4 and parts[1] == 'support':
+                        # {course_dir}/support/{module_name}/...
+                        module_path = '/'.join(parts[:3])
+                        category = 'support'
+
+                    if module_path and category:
+                        key = (course_code, module_path)
+                        if key not in seen:
+                            seen.add(key)
+                            # Only insert if it doesn't already exist
+                            existing = session.query(ModuleModel).filter_by(
+                                course_code=course_code, path=module_path
+                            ).first()
+                            if not existing:
+                                new_modules.append(ModuleModel(
+                                    uuid=str(uuid_lib.uuid4()),
+                                    name=module_path.split('/')[-1],
+                                    path=module_path,
+                                    category=category,
+                                    course_code=course_code,
+                                ))
+
+                if new_modules:
+                    session.add_all(new_modules)
+                    session.commit()
+                    logger.info(f"✅ Populated {len(new_modules)} new modules")
+                else:
+                    logger.info("✅ Module table already up to date")
+
+                return True
+            except Exception as e:
+                session.rollback()
+                logger.error(f"❌ Failed to populate modules: {e}")
+                return False
+            finally:
+                session.close()
+        except Exception as e:
+            logger.error(f"❌ Module population error: {e}")
             return False
 
     def get_database_status(self) -> Dict:

--- a/ai_chatbot_backend/app/core/models/chat_completion.py
+++ b/ai_chatbot_backend/app/core/models/chat_completion.py
@@ -127,6 +127,7 @@ class UserFocus(BaseModel):
     file_uuid: UUID
     selected_text: str = None
     chunk_index: float = None
+    module_uuid: Optional[str] = None  # Optional: restrict RAG scope to this module
 
 class GeneralCompletionParams(BaseModel):
     """

--- a/ai_chatbot_backend/app/core/models/metadata.py
+++ b/ai_chatbot_backend/app/core/models/metadata.py
@@ -1,8 +1,8 @@
 """
-Models for metadata database (files and problems)
+Models for metadata database (files, problems, modules)
 """
 
-from sqlalchemy import Column, String, Integer, Float, Text
+from sqlalchemy import Column, String, Integer, Float, Text, UniqueConstraint
 from app.core.dbs.metadata_db import MetadataBase
 
 
@@ -41,3 +41,21 @@ class ProblemModel(MetadataBase):
 
     def __repr__(self):
         return f"<Problem(uuid={self.uuid}, file_uuid={self.file_uuid}, question_id={self.question_id})>"
+
+
+class ModuleModel(MetadataBase):
+    """Module model for metadata database — represents a logical grouping of course files"""
+    __tablename__ = "module"
+
+    uuid = Column(String, primary_key=True, index=True)
+    name = Column(String, nullable=False)          # Last path segment (e.g., "lab01")
+    path = Column(String, nullable=False)          # Full relative path (e.g., "practice/labs/lab01")
+    category = Column(String, nullable=False)      # "practice", "study", or "support"
+    course_code = Column(String, nullable=False, index=True)
+
+    __table_args__ = (
+        UniqueConstraint("course_code", "path", name="uq_module_course_path"),
+    )
+
+    def __repr__(self):
+        return f"<Module(uuid={self.uuid}, path={self.path}, course={self.course_code})>"

--- a/ai_chatbot_backend/app/schemas/modules.py
+++ b/ai_chatbot_backend/app/schemas/modules.py
@@ -1,0 +1,45 @@
+"""
+Module schemas for API responses
+"""
+
+from typing import List
+from pydantic import BaseModel, Field
+
+
+class Module(BaseModel):
+    """Represents a module (subdirectory) within a course"""
+
+    module_uuid: str = Field(..., description="Unique module identifier")
+    name: str = Field(..., description="Module name (directory name)")
+    path: str = Field(..., description="Full path relative to course root")
+    category: str = Field(..., description="Module category (practice, study, support)")
+    course_code: str = Field(..., description="Course code this module belongs to")
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "module_uuid": "550e8400-e29b-41d4-a716-446655440000",
+                "name": "week1",
+                "path": "study/week1",
+                "category": "study",
+                "course_code": "CS61A"
+            }
+        }
+
+    @classmethod
+    def from_db_model(cls, m) -> "Module":
+        return cls(
+            module_uuid=m.uuid,
+            name=m.name,
+            path=m.path,
+            category=m.category,
+            course_code=m.course_code,
+        )
+
+
+class ModuleListResponse(BaseModel):
+    """Response for module listing"""
+
+    modules: List[Module] = Field(..., description="List of modules")
+    total_count: int = Field(..., description="Total number of modules")
+    course_code: str = Field(..., description="Course code")

--- a/ai_chatbot_backend/app/services/generation/chat/__init__.py
+++ b/ai_chatbot_backend/app/services/generation/chat/__init__.py
@@ -16,6 +16,7 @@ async def run_chat_pipeline(
     sid: Optional[str] = None,
     timer: Optional[RequestTimer] = None,
     audio_text: Optional[str] = None,
+    module_path: Optional[str] = None,
 ):
     """
     Regular chat pipeline: query -> generate -> handler.
@@ -31,6 +32,7 @@ async def run_chat_pipeline(
         messages, user_focus, answer_content, problem_content,
         course, engine, sid, timer,
         audio_response=audio_response,
+        module_path=module_path,
     )
 
     # Step 2: Generate — call LLM

--- a/ai_chatbot_backend/app/services/generation/chat/query.py
+++ b/ai_chatbot_backend/app/services/generation/chat/query.py
@@ -28,6 +28,7 @@ async def build_chat_context(
     sid: Optional[str],
     timer: Optional[RequestTimer],
     audio_response: bool = False,
+    module_path: Optional[str] = None,
 ) -> ChatContext:
     """
     Step 1: Build the complete prompt context for regular (non-tutor) chat mode.
@@ -110,7 +111,8 @@ async def build_chat_context(
         query_message=query_message,
         audio_response=audio_response,
         tutor_mode=False,
-        timer=timer
+        timer=timer,
+        module_path=module_path,  # Resolved from module_uuid by caller
     )
 
     messages[-1].content += modified_message

--- a/ai_chatbot_backend/app/services/generation/tutor/__init__.py
+++ b/ai_chatbot_backend/app/services/generation/tutor/__init__.py
@@ -16,6 +16,7 @@ async def run_tutor_pipeline(
     sid: Optional[str] = None,
     timer: Optional[RequestTimer] = None,
     audio_text: Optional[str] = None,
+    module_path: Optional[str] = None,
 ):
     """
     Tutor pipeline: query -> generate -> handler.

--- a/ai_chatbot_backend/app/services/module_service.py
+++ b/ai_chatbot_backend/app/services/module_service.py
@@ -1,0 +1,63 @@
+"""
+Module service for managing course modules via the module table
+"""
+
+from typing import Dict, List, Optional
+from sqlalchemy.orm import Session
+from sqlalchemy import and_
+
+from app.core.models.metadata import FileModel, ModuleModel
+
+
+class ModuleService:
+    """Service for querying course modules from the database."""
+
+    def list_modules(self, db: Session, course_code: str) -> List[ModuleModel]:
+        """Return all modules for a course, ordered by path."""
+        return (
+            db.query(ModuleModel)
+            .filter(ModuleModel.course_code == course_code)
+            .order_by(ModuleModel.path)
+            .all()
+        )
+
+    def get_by_uuid(self, db: Session, module_uuid: str) -> Optional[ModuleModel]:
+        """Return a module by its UUID, or None if not found."""
+        return db.query(ModuleModel).filter(ModuleModel.uuid == module_uuid).first()
+
+    def get_module_files(
+        self, db: Session, module_uuid: str
+    ) -> List[FileModel]:
+        """
+        Return all files within the module identified by module_uuid.
+
+        Raises:
+            ValueError: If no module with the given UUID exists.
+        """
+        module = self.get_by_uuid(db, module_uuid)
+        if not module:
+            raise ValueError(f"Module not found: {module_uuid}")
+
+        # module.path already includes the course directory prefix
+        # e.g. "CS 61A/practice/hw/hw01" — so match relative_path directly
+        return (
+            db.query(FileModel)
+            .filter(FileModel.relative_path.like(f"{module.path}/%"))
+            .all()
+        )
+
+    def get_module_path(self, db: Session, module_uuid: str) -> str:
+        """
+        Resolve a module UUID to its path string for RAG filtering.
+
+        Raises:
+            ValueError: If no module with the given UUID exists.
+        """
+        module = self.get_by_uuid(db, module_uuid)
+        if not module:
+            raise ValueError(f"Module not found: {module_uuid}")
+        return module.path
+
+
+# Global service instance
+module_service = ModuleService()

--- a/ai_chatbot_backend/app/services/query/prompt_assembly.py
+++ b/ai_chatbot_backend/app/services/query/prompt_assembly.py
@@ -18,7 +18,9 @@ def build_augmented_prompt(
         answer_content: Optional[str] = None,
         audio_response: bool = False,
         tutor_mode: bool = True,
-        timer: Optional[RequestTimer] = None
+        timer: Optional[RequestTimer] = None,
+        module_path: Optional[str] = None,
+        file_uuid=None
 ) -> Tuple[str, List[Dict], str]:
     """
     Build an augmented prompt by retrieving reference documents.
@@ -42,7 +44,12 @@ def build_augmented_prompt(
             f"Instruction: {user_message}"
         )
     # Print parameter information
-    print('\n Course: \n', course, '\n')
+    scope_info = f"Course: {course}"
+    if file_uuid:
+        scope_info += f", File: {file_uuid}"
+    elif module_path:
+        scope_info += f", Module: {module_path}"
+    print(f'\n{scope_info}\n')
     print("\nUser Question: \n", user_message, "\n")
     print('time of the day:', time.strftime('%Y-%m-%d %H:%M:%S', time.localtime()), '\n')
     # No need to retrieve documents if rag is False
@@ -55,7 +62,10 @@ def build_augmented_prompt(
     (
         top_chunk_uuids, top_docs, top_urls, similarity_scores, top_files, top_refs, top_titles,
         top_file_uuids, top_chunk_idxs
-    ), class_name = get_reference_documents(query_message, course, top_k=top_k, timer=timer)
+    ), class_name = get_reference_documents(
+        query_message, course, top_k=top_k, timer=timer,
+        module_path=module_path, file_uuid=file_uuid
+    )
     # Prepare the insert document and reference list
     # Collect file UUIDs that pass threshold, then batch-fetch their descriptions
     passing_indices = [i for i in range(len(top_docs)) if similarity_scores[i] > threshold]

--- a/ai_chatbot_backend/app/services/query/vector_search.py
+++ b/ai_chatbot_backend/app/services/query/vector_search.py
@@ -15,6 +15,7 @@ from app.services.query.embedding import (
     EMBEDDING_PICKLE_PATH, SQLDB,
 )
 from app.services.query.course_mapping import _get_pickle_and_class
+from app.utils.path_validation import is_valid_module_path
 
 if TYPE_CHECKING:
     from app.services.request_timer import RequestTimer
@@ -27,10 +28,23 @@ _desc_lock = threading.Lock()
 
 
 def get_reference_documents(
-    query: str, course: str, top_k: int, timer: Optional["RequestTimer"] = None
+    query: str,
+    course: str,
+    top_k: int,
+    timer: Optional["RequestTimer"] = None,
+    module_path: Optional[str] = None,
+    file_uuid: Optional[UUID] = None
 ) -> Tuple[Tuple[List[str], List[str], List[str], List[float], List[str], List[str], List[str]], str]:
     """
     Retrieve top reference documents based on the query embedding and choice of DB-type.
+
+    Args:
+        query: Search query
+        course: Course code
+        top_k: Number of top results to return
+        timer: Optional request timer
+        module_path: Optional module path to restrict search (e.g., "practice/labs/lab01")
+        file_uuid: Optional file UUID to restrict search to a specific file
     """
     class_name = _get_pickle_and_class(course)
 
@@ -52,7 +66,10 @@ def get_reference_documents(
     t1 = time.time()
 
     if SQLDB:
-        output = _get_references_from_sql(query_embed, course, top_k=top_k)
+        output = _get_references_from_sql(
+            query_embed, course, top_k=top_k,
+            module_path=module_path, file_uuid=file_uuid
+        )
 
     # Mark retrieval end
     if timer:
@@ -334,17 +351,28 @@ def get_file_related_documents(
     return _get_references_from_sql(query_embed, course, top_k)
 
 def _get_references_from_sql(
-    query_embed: Dict[str, Any], course: str, top_k: int
+    query_embed: Dict[str, Any],
+    course: str,
+    top_k: int,
+    module_path: Optional[str] = None,
+    file_uuid: Optional[UUID] = None
 ) -> Tuple[List[str], List[str], List[str], List[float], List[str], List[str], List[str], List[str], List[float]]:
     """
     Retrieve top reference documents from a SQL database.
+
+    Args:
+        query_embed: Query embedding dictionary
+        course: Course code
+        top_k: Number of top results to return
+        module_path: Optional module path to restrict search
+        file_uuid: Optional file UUID to restrict search to a specific file
     """
     # Convert the query embedding to a numpy array
     qv = np.array(query_embed["dense_vecs"], dtype=np.float32).reshape(-1)
     if qv.size == 0:
         return [], [], [], [], [], [], [],[], []
     # Get the course index from the cache or build it if not present or stale
-    idx = _get_course_index(course)
+    idx = _get_course_index(course, module_path=module_path, file_uuid=file_uuid)
     if not idx.get("M") is not None:
         return [], [], [], [], [], [], [],[], []
     # Compute the scores for each document in the index
@@ -366,32 +394,79 @@ def _get_references_from_sql(
     return top_chunk_uuids, top_texts, top_urls, top_scores, top_file_paths, top_reference_paths, top_titles, top_file_uuids, top_chunk_idxs
 
 
-def _get_course_index(course: str):
+def _get_course_index(
+    course: str,
+    module_path: Optional[str] = None,
+    file_uuid: Optional[UUID] = None
+):
     """
-    Get the course index from the cache or build it if not present or stale.
+    Get the course/module/file index from the cache or build it if not present or stale.
+
+    Args:
+        course: Course code
+        module_path: Optional module path to restrict index
+        file_uuid: Optional file UUID to restrict index to a specific file
     """
+    # Create a cache key based on scope
+    if file_uuid:
+        cache_key = f"{course}:file:{file_uuid}"
+    elif module_path:
+        cache_key = f"{course}:module:{module_path}"
+    else:
+        cache_key = course
+
     with _course_lock:
-        idx = _course_cache.get(course)
+        idx = _course_cache.get(cache_key)
+
     # check staleness
     with _get_cursor() as cur:
         dv_now = cur.execute("PRAGMA data_version").fetchone()[0]
+
     if idx is None or idx["dv"] != dv_now or idx.get("M") is None:
-        idx = _build_course_index(course)
+        idx = _build_course_index(course, module_path=module_path, file_uuid=file_uuid)
         with _course_lock:
-            _course_cache[course] = idx
+            _course_cache[cache_key] = idx
+
     return idx
 
 
-def _build_course_index(course: str):
+def _build_course_index(
+    course: str,
+    module_path: Optional[str] = None,
+    file_uuid: Optional[UUID] = None
+):
     """
-    Build an index of all chunks in the database for a specific course.
+    Build an index of chunks in the database for a specific scope.
+
+    Args:
+        course: Course code
+        module_path: Optional module path to restrict index (e.g., "practice/labs/lab01")
+        file_uuid: Optional file UUID to restrict index to a specific file
+
+    Raises:
+        ValueError: If module_path is invalid
     """
+    # Prevent path traversal (module_path comes from DB but guard defensively)
+    if module_path and ('..' in module_path or module_path.startswith('/')):
+        raise ValueError(f"Invalid module path: {module_path}")
+
     # Prepare connection params to the SQLite database
     where = "WHERE vector IS NOT NULL"
     params = []
+
+    # Filter by course
     if course and course != "general":
         where += " AND course_code = ?"
         params.append(course)
+
+    # Filter by file UUID (most specific)
+    if file_uuid:
+        where += " AND file_uuid = ?"
+        params.append(str(file_uuid))
+    # Filter by module path (if not filtering by file)
+    elif module_path:
+        where += " AND file_path LIKE ?"
+        params.append(f"{module_path}/%")
     # Use a context manager to get SQL-DB cursor to ensure the connection is closed properly
     with _get_cursor() as cur:
         dv = cur.execute("PRAGMA data_version").fetchone()[0]

--- a/ai_chatbot_backend/app/utils/path_validation.py
+++ b/ai_chatbot_backend/app/utils/path_validation.py
@@ -1,0 +1,45 @@
+"""
+Path validation utilities for module paths
+"""
+
+
+def is_valid_module_path(module_path: str) -> bool:
+    """
+    Validate that a module path follows the valid module structure.
+
+    Valid patterns:
+    - practice/*/<name> (3 parts, first is 'practice')
+    - study/<name> (2 parts, first is 'study')
+    - support/<name> (2 parts, first is 'support')
+
+    Args:
+        module_path: Module path to validate
+
+    Returns:
+        True if valid, False otherwise
+    """
+    if not module_path or not isinstance(module_path, str):
+        return False
+
+    # Normalize path separators and remove trailing slashes
+    normalized_path = module_path.strip().rstrip('/')
+
+    # Prevent path traversal attempts
+    if '..' in normalized_path or normalized_path.startswith('/'):
+        return False
+
+    parts = normalized_path.split('/')
+
+    # Check for practice/*/<name> pattern (exactly 3 parts)
+    if len(parts) == 3 and parts[0] == 'practice':
+        return True
+
+    # Check for study/<name> pattern (exactly 2 parts)
+    if len(parts) == 2 and parts[0] == 'study':
+        return True
+
+    # Check for support/<name> pattern (exactly 2 parts)
+    if len(parts) == 2 and parts[0] == 'support':
+        return True
+
+    return False

--- a/ai_chatbot_backend/docs/api-files-modules.md
+++ b/ai_chatbot_backend/docs/api-files-modules.md
@@ -1,0 +1,375 @@
+# Files & Modules API Reference
+
+Base URL: `/api`
+
+All endpoints require a valid API token in the `Authorization` header (Bearer token).
+
+---
+
+## Overview
+
+TAI organizes course content into **files** and **modules**:
+
+- **Files** are individual documents (PDFs, HTML pages, Python files, videos) stored in the `metadata.db` database. Every file has a UUID, a `relative_path` showing its location in the course directory tree, and structured `sections` extracted from the content.
+- **Modules** are logical groupings of files derived from the course directory structure. Each module has a stable UUID that won't change across server restarts. Modules follow a fixed hierarchy:
+
+```
+{course_dir}/
+  practice/
+    hw/hw01/        -> module (category: practice)
+    hw/hw02/        -> module
+    lab/lab00/       -> module
+    proj/hog/        -> module
+  study/
+    lec01/           -> module (category: study)
+    lec02/           -> module
+  support/
+    articles/        -> module (category: support)
+    resources/       -> module
+```
+
+**When should the frontend use modules vs files?**
+- Use **modules** to build a sidebar/navigation tree showing course structure (practice > hw > hw01, study > lec01, etc.)
+- Use **files** when you need the actual content — file details, download links, or to pass a `file_uuid` to the chat API
+- Use `module_uuid` in the **chat completions API** to scope RAG retrieval to a specific module (e.g., only search within lab01 materials)
+
+---
+
+## Modules API
+
+### List Modules
+
+```
+GET /api/modules?course_code={course_code}
+```
+
+Returns all modules for a course, sorted by path.
+
+**Query Parameters:**
+
+| Parameter     | Type   | Required | Description                      |
+|---------------|--------|----------|----------------------------------|
+| `course_code` | string | yes      | Course code, e.g. `CS 61A`      |
+
+**Response:**
+
+```json
+{
+  "modules": [
+    {
+      "module_uuid": "7c49c2d9-89b9-43a5-9732-9b84f2bf019e",
+      "name": "hw01",
+      "path": "CS 61A/practice/hw/hw01",
+      "category": "practice",
+      "course_code": "CS 61A"
+    },
+    {
+      "module_uuid": "31578c41-f9e9-4e06-8b38-56b4a6e4eb62",
+      "name": "lec01",
+      "path": "CS 61A/study/lec01",
+      "category": "study",
+      "course_code": "CS 61A"
+    }
+  ],
+  "total_count": 57,
+  "course_code": "CS 61A"
+}
+```
+
+**Response fields:**
+
+| Field           | Type   | Description                                           |
+|-----------------|--------|-------------------------------------------------------|
+| `module_uuid`   | string | Stable UUID for this module. Use this in other APIs.  |
+| `name`          | string | Short display name (last path segment): `hw01`, `lec01` |
+| `path`          | string | Full directory path including course prefix            |
+| `category`      | string | One of: `practice`, `study`, `support`                |
+| `course_code`   | string | The course this module belongs to                     |
+
+**Frontend usage notes:**
+- Group modules by `category` to build a navigation tree
+- Within `practice`, you can further group by the 3rd path segment (`hw`, `lab`, `proj`) parsed from `path`
+- `module_uuid` is stable across server restarts — safe to persist in URLs and local storage
+- `path` is for display only; always use `module_uuid` to identify modules in API calls
+
+---
+
+### List Files in Module
+
+```
+GET /api/modules/{module_uuid}/files
+```
+
+Returns all files belonging to a specific module. Supports pagination.
+
+**Path Parameters:**
+
+| Parameter      | Type   | Required | Description        |
+|----------------|--------|----------|--------------------|
+| `module_uuid`  | string | yes      | Module UUID        |
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Default | Description      |
+|-----------|------|----------|---------|------------------|
+| `page`    | int  | no       | 1       | Page number      |
+| `limit`   | int  | no       | 100     | Items per page (max 1000) |
+
+**Response:** Same `FileListResponse` schema as the files API (see below).
+
+**Error responses:**
+
+| Status | Condition                     |
+|--------|-------------------------------|
+| 404    | Module UUID not found         |
+
+---
+
+## Files API
+
+### List Files
+
+```
+GET /api/files
+```
+
+List files with filtering, search, and pagination.
+
+**Query Parameters:**
+
+| Parameter     | Type   | Required | Default | Description                               |
+|---------------|--------|----------|---------|-------------------------------------------|
+| `course_code` | string | no       | —       | Filter by course code                     |
+| `category`    | string | no       | —       | Filter by category (document, video, audio, other) |
+| `search`      | string | no       | —       | Search in file names and titles           |
+| `path`        | string | no       | —       | Filter by directory path prefix           |
+| `page`        | int    | no       | 1       | Page number                               |
+| `limit`       | int    | no       | 100     | Items per page (max 1000)                 |
+
+**Response (`FileListResponse`):**
+
+```json
+{
+  "files": [
+    {
+      "uuid": "a1b2c3d4-...",
+      "filename": "Homework 1 CS 61A Summer 2025.html",
+      "title": "Homework 1 Cs 61A Summer 2025",
+      "relative_path": "CS 61A/practice/hw/hw01/hw01/Homework 1 CS 61A Summer 2025.html",
+      "size_bytes": 45231,
+      "mime_type": "text/html",
+      "created_at": null,
+      "modified_at": null,
+      "course": "CS 61A",
+      "category": null,
+      "sections": [
+        {
+          "name": "Required Questions",
+          "index": 1.0,
+          "key_concept": "Q1: A Plus Abs B",
+          "aspects": [
+            {
+              "content": "Fill in the blanks...",
+              "type": "Definition"
+            }
+          ],
+          "checking_questions": null,
+          "comprehensive_questions": null
+        }
+      ],
+      "download_url": "/api/files/a1b2c3d4-.../download",
+      "original_url": "https://cs61a.org/hw/hw01/"
+    }
+  ],
+  "total_count": 42,
+  "page": 1,
+  "limit": 100,
+  "has_next": false,
+  "has_prev": false,
+  "filters_applied": {
+    "course_code": "CS 61A",
+    "category": null,
+    "search": null,
+    "path": null
+  }
+}
+```
+
+**File fields:**
+
+| Field           | Type             | Description                                      |
+|-----------------|------------------|--------------------------------------------------|
+| `uuid`          | string           | File UUID — use this to reference the file       |
+| `filename`      | string           | Original filename                                |
+| `title`         | string \| null   | Auto-generated display title                     |
+| `relative_path` | string           | Full path in the course directory tree           |
+| `size_bytes`    | int              | File size (0 if file not found on disk)          |
+| `mime_type`     | string           | MIME type (e.g., `application/pdf`, `text/html`) |
+| `course`        | string \| null   | Course code                                      |
+| `sections`      | Section[]        | Parsed educational sections (see below)          |
+| `download_url`  | string           | Relative URL to download this file               |
+| `original_url`  | string \| null   | Source URL where the file was collected from      |
+
+**Section schema:**
+
+| Field                      | Type               | Description                          |
+|----------------------------|---------------------|--------------------------------------|
+| `name`                     | string              | Section title                        |
+| `index`                    | float               | Section order/position               |
+| `key_concept`              | string              | Main topic                           |
+| `aspects`                  | SectionAspect[]     | List of content aspects              |
+| `checking_questions`       | string[] \| null    | Quick comprehension questions        |
+| `comprehensive_questions`  | string[] \| null    | Deeper review questions              |
+
+---
+
+### Browse Directory
+
+```
+GET /api/files/browse?course_code={course_code}&path={path}
+```
+
+Hierarchical directory browser. Returns immediate subdirectories and files at the given path.
+
+**Query Parameters:**
+
+| Parameter     | Type   | Required | Default | Description                                |
+|---------------|--------|----------|---------|--------------------------------------------|
+| `course_code` | string | yes      | —       | Course code                                |
+| `path`        | string | no       | `""`    | Directory path within course (empty = root)|
+
+**Response (`DirectoryBrowserResponse`):**
+
+```json
+{
+  "directories": [
+    {
+      "name": "practice",
+      "path": "CS 61A/practice",
+      "file_count": 45,
+      "has_subdirs": true
+    }
+  ],
+  "files": [],
+  "current_path": "",
+  "breadcrumbs": [
+    { "name": "Root", "path": "" }
+  ],
+  "course_code": "CS 61A"
+}
+```
+
+---
+
+### Get File Metadata
+
+```
+GET /api/files/{file_id}
+```
+
+Returns full metadata for a single file. Same `FileMetadata` schema as in list responses.
+
+| Status | Condition              |
+|--------|------------------------|
+| 404    | File UUID not found    |
+
+---
+
+### Download File
+
+```
+GET /api/files/{file_id}/download
+```
+
+Returns the raw file content with correct MIME type and `Content-Disposition` headers.
+
+| Status | Condition              |
+|--------|------------------------|
+| 404    | File UUID not found    |
+
+---
+
+### Get File Extra Info (Transcript)
+
+```
+GET /api/files/{file_id}/extra_info
+```
+
+Returns video transcript segments for files that have transcript data.
+
+**Response:** `TranscriptSegment[]`
+
+```json
+[
+  {
+    "start_time": 0.0,
+    "end_time": 15.5,
+    "speaker": "instructor",
+    "text_content": "Welcome to CS 61A..."
+  }
+]
+```
+
+Returns `[]` if no transcript data is available.
+
+---
+
+## Using Modules with Chat Completions
+
+When sending a file-chat completion request (`POST /api/chat/completions` with `chat_type: "file"`), you can optionally include `module_uuid` in the `user_focus` object to restrict RAG retrieval to files within that module.
+
+**Without `module_uuid`:** RAG searches across all files in the course.
+
+**With `module_uuid`:** RAG only searches within files belonging to that module.
+
+```json
+{
+  "course_code": "CS 61A",
+  "chat_type": "file",
+  "messages": [
+    { "role": "user", "content": "Explain the map function from this lab" }
+  ],
+  "stream": true,
+  "user_focus": {
+    "file_uuid": "a1b2c3d4-...",
+    "module_uuid": "79ada5b9-541c-4f03-a357-8c7228dc63aa"
+  }
+}
+```
+
+This is useful when the student is viewing a specific module (e.g., lab01) and you want the AI to prioritize references from that module's materials rather than pulling from unrelated parts of the course.
+
+**Error responses:**
+
+| Status | Condition                           |
+|--------|-------------------------------------|
+| 404    | `module_uuid` not found in database |
+| 400    | Invalid request parameters          |
+
+---
+
+## Common Patterns
+
+### Building a Module Navigation Sidebar
+
+```
+1. GET /api/modules?course_code=CS 61A
+2. Group response by category (practice, study, support)
+3. For practice modules, further group by path segment:
+   - "CS 61A/practice/hw/hw01"  -> hw > hw01
+   - "CS 61A/practice/lab/lab01" -> lab > lab01
+   - "CS 61A/practice/proj/hog"  -> proj > hog
+4. On click, fetch files:
+   GET /api/modules/{module_uuid}/files
+```
+
+### Opening a File Chat with Module Scope
+
+```
+1. User selects a module (e.g., lab01)
+2. Load files: GET /api/modules/{module_uuid}/files
+3. User selects a file
+4. Send chat with both file and module context:
+   POST /api/chat/completions
+   { user_focus: { file_uuid: "...", module_uuid: "..." } }
+```

--- a/rag/file_conversion_router/services/directory_service.py
+++ b/rag/file_conversion_router/services/directory_service.py
@@ -433,6 +433,9 @@ def process_folder(
     if deleted_count > 0:
         logging.info(f"Database cleanup completed: {deleted_count} deleted file(s) removed")
 
+    # Populate module table from file paths
+    populate_modules(conn, course_code)
+
     # Generate embeddings if requested
     if generate_embeddings:
         logging.info(f"Generating embeddings for course: {course_code}")
@@ -495,6 +498,70 @@ def cleanup_deleted_files(conn: sqlite3.Connection, course_code: str, input_dir_
         logging.info(f"[CLEANUP] Removed {deleted_count} deleted file(s) from database")
 
     return deleted_count
+
+
+def populate_modules(conn: sqlite3.Connection, course_code: str) -> int:
+    """
+    Scan the file table to derive modules and upsert them into the module table.
+    Idempotent — uses ON CONFLICT DO NOTHING so existing rows are preserved.
+
+    Module detection rules (relative_path includes course dir prefix):
+      - practice/*/*/<name>/... → category "practice"  (parts[:4])
+      - study/<name>/...        → category "study"      (parts[:3])
+      - support/<name>/...      → category "support"    (parts[:3])
+
+    Returns the number of new module rows inserted.
+    """
+    rows = conn.execute(
+        "SELECT relative_path FROM file WHERE course_code = ? AND relative_path LIKE '%/%'",
+        (course_code,),
+    ).fetchall()
+
+    seen: set = set()
+    new_count = 0
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        for (relative_path,) in rows:
+            if not relative_path:
+                continue
+            parts = relative_path.split('/')
+            module_path = None
+            category = None
+
+            if len(parts) >= 5 and parts[1] == 'practice':
+                module_path = '/'.join(parts[:4])   # {course_dir}/practice/{sub}/{name}
+                category = 'practice'
+            elif len(parts) >= 4 and parts[1] == 'study':
+                module_path = '/'.join(parts[:3])   # {course_dir}/study/{name}
+                category = 'study'
+            elif len(parts) >= 4 and parts[1] == 'support':
+                module_path = '/'.join(parts[:3])   # {course_dir}/support/{name}
+                category = 'support'
+
+            if module_path and module_path not in seen:
+                seen.add(module_path)
+                module_name = parts[3] if category == 'practice' else parts[2]
+                conn.execute(SQL_UPSERT_MODULE, (
+                    str(uuid.uuid4()),
+                    module_name,
+                    module_path,
+                    category,
+                    course_code,
+                ))
+                new_count += 1
+
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+    if new_count:
+        logging.info(f"Populated {new_count} new module(s) for course {course_code}")
+    else:
+        logging.info(f"Module table already up to date for course {course_code}")
+
+    return new_count
 
 
 def _load_patterns(ignore_file=None,
@@ -821,6 +888,17 @@ CREATE TABLE IF NOT EXISTS problem (
   question_type   TEXT DEFAULT 'regular',
   FOREIGN KEY (file_uuid) REFERENCES file(uuid) ON DELETE CASCADE
 );
+
+CREATE TABLE IF NOT EXISTS module (
+  uuid        TEXT PRIMARY KEY,
+  name        TEXT NOT NULL,
+  path        TEXT NOT NULL,
+  category    TEXT NOT NULL,
+  course_code TEXT NOT NULL,
+  UNIQUE(course_code, path)
+);
+
+CREATE INDEX IF NOT EXISTS idx_module_course ON module(course_code);
 """
 SQL_UPSERT_FILE = """
 INSERT INTO file (uuid, file_hash, sections, relative_path, course_code, course_name, file_name, description, extra_info, url, created_at, update_time)
@@ -880,3 +958,9 @@ SQL_SELECT_FILE_UUID_BY_HASH = "SELECT uuid FROM file WHERE file_hash=?;"
 SQL_SELECT_FILES_BY_COURSE = "SELECT uuid, relative_path, file_name FROM file WHERE course_code=?;"
 
 SQL_DELETE_FILE_CASCADE = "DELETE FROM file WHERE uuid=?;"
+
+SQL_UPSERT_MODULE = """
+INSERT INTO module (uuid, name, path, category, course_code)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(course_code, path) DO NOTHING;
+"""

--- a/rag/file_conversion_router/utils/database_merger.py
+++ b/rag/file_conversion_router/utils/database_merger.py
@@ -5,7 +5,7 @@ import sqlite3
 from pathlib import Path
 from typing import List, Dict
 
-from file_conversion_router.services.directory_service import SQL_INIT
+from file_conversion_router.services.directory_service import SQL_INIT, SQL_UPSERT_MODULE
 
 
 def merge_course_databases_into_collective(
@@ -135,6 +135,11 @@ def _delete_course_data_from_collective(
             "DELETE FROM file WHERE course_code = ?", (course_code,)
         )
 
+        # Delete modules for this course
+        collective_conn.execute(
+            "DELETE FROM module WHERE course_code = ?", (course_code,)
+        )
+
         logging.info(f"Deleted existing course data for {course_code}: {deletion_stats}")
 
     except Exception as e:
@@ -159,7 +164,7 @@ def _merge_single_course_db(
     course_conn.row_factory = sqlite3.Row
     collective_conn.row_factory = sqlite3.Row
 
-    stats = {"files": 0, "chunks": 0, "problems": 0, "conflicts": 0, "deleted": {}}
+    stats = {"files": 0, "chunks": 0, "problems": 0, "modules": 0, "conflicts": 0, "deleted": {}}
 
     # Get all files from course database to determine course_code
     files = course_conn.execute("SELECT * FROM file").fetchall()
@@ -260,6 +265,22 @@ def _merge_single_course_db(
                 problem_row['explanation'], problem_row['question_type']
             ))
             stats["problems"] += 1
+
+    # Merge modules for this course (table may not exist in older course DBs)
+    try:
+        modules = course_conn.execute(
+            "SELECT uuid, name, path, category, course_code FROM module WHERE course_code = ?",
+            (course_code,),
+        ).fetchall()
+        for mod_row in modules:
+            collective_conn.execute(SQL_UPSERT_MODULE, (
+                mod_row['uuid'], mod_row['name'], mod_row['path'],
+                mod_row['category'], mod_row['course_code'],
+            ))
+            stats["modules"] += 1
+    except Exception:
+        # Older course databases may not have a module table yet; skip gracefully
+        pass
 
     return stats
 


### PR DESCRIPTION
## Summary

- **Modules API**: New `GET /api/modules` and `GET /api/modules/{module_uuid}/files` endpoints; modules are identified by stable UUIDs
- **Module-scoped RAG**: Add `module_uuid` to `UserFocus`; resolved to a path at the API boundary and threaded through the entire chat pipeline to scope vector search to a single module
- **Metadata DB**: Add `module` table (UUID PK, unique on `course_code + path`); backend auto-populates it on startup by scanning file paths
- **RAG pipeline**: `directory_service.py` creates the `module` table in `SQL_INIT` and calls `populate_modules()` after each folder is processed; `database_merger.py` merges and clears module rows alongside files/chunks/problems

## Test plan

- [x] `GET /api/modules?course_code=CS61A` returns list of modules with UUIDs
- [x] `GET /api/modules/{uuid}/files` returns files for that module
- [x] Chat completion with unknown `module_uuid` returns 404


🤖 Generated with [Claude Code](https://claude.com/claude-code)